### PR TITLE
Fix missing backslash and incorrect string class

### DIFF
--- a/classes/loginflow/authcode.php
+++ b/classes/loginflow/authcode.php
@@ -477,7 +477,7 @@ class authcode extends \auth_azureb2c\loginflow\base {
                     if (!$CFG->allowaccountssameemail) {
                         $info = $this->get_userinfo($username);
                         if ($DB->count_records('user', array('email' => $info['email'], 'deleted' => 0)) > 0) {
-                            throw new moodle_exception('errorauthloginfaileddupemail', 'auth_oidc', null, null, '1'); 
+                            throw new \moodle_exception('errorauthloginfaileddupemail', 'auth_azureb2c', null, null, '1'); 
                         }
                     }
                     $user = create_user_record($username, null, 'azureb2c');


### PR DESCRIPTION
A minor fix after I caused this particular error - the moodle_exception should be backslashed, and the string should use this plugin's name not auth_oidc.