### PR TITLE
Cleanup leftover results of a failed auth

### DIFF
--- a/classes/loginflow/authcode.php
+++ b/classes/loginflow/authcode.php
@@ -438,6 +438,8 @@ class authcode extends \auth_azureb2c\loginflow\base {
             }
             $user = $DB->get_record('user', ['id' => $tokenrec->userid]);
             if (empty($user)) {
+                // Usually the result of a failed auth - clean it up.
+                $DB->delete_record('auth_azureb2c_token', ['azureb2cuniqid' => $azureb2cuniqid]);
                 // ERROR.
                 echo 'ERROR2';die();
             }


### PR DESCRIPTION
If the auth previously failed at the wrong spot, azureb2c_token.userid=0 and the record is useless, but causes subsequent auth attempts to fail.  Clean it up so future auth attempts don't fail due to this.